### PR TITLE
Fix SVG and PNG export in VS Code webview

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,7 +115,7 @@ export function activate(context: vscode.ExtensionContext) {
 			panel.webview.html = html;
 
 			panel.webview.onDidReceiveMessage(
-				message => {
+				async message => {
 				  switch (message.command) {
 					case 'alert':
 						vscode.window.showErrorMessage(message.text);
@@ -125,6 +125,29 @@ export function activate(context: vscode.ExtensionContext) {
 							command: "transmit_model", 
 							value: Uint8Array.from(fs.readFileSync(modelFile!)).subarray()});
 						return;
+					case 'export': {
+						const fileName = path.basename(message.file || `${baseName}.png`);
+						const extension = path.extname(fileName).replace(/^\./, '').toLowerCase();
+						const filters = extension ? { [extension.toUpperCase()]: [extension] } : undefined;
+						const defaultUri = vscode.Uri.file(path.join(path.dirname(modelFile!), fileName));
+
+						try {
+							const uri = await vscode.window.showSaveDialog({
+								defaultUri,
+								filters,
+								saveLabel: 'Export'
+							});
+							if (uri) {
+								await vscode.workspace.fs.writeFile(uri, Uint8Array.from(message.data || []));
+							}
+							panel.webview.postMessage({ command: 'export_complete', id: message.id });
+						} catch (error) {
+							const text = error instanceof Error ? error.message : String(error);
+							panel.webview.postMessage({ command: 'export_complete', id: message.id, error: text });
+							vscode.window.showErrorMessage(text);
+						}
+						return;
+					}
 				  }
 				},
 				undefined,

--- a/webview/index.html
+++ b/webview/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="description" content="Visualizer for neural network, deep learning and machine learning models." />
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-<meta http-equiv="Content-Security-Policy" content="default-src %webview_cspSource%; style-src %webview_cspSource% 'unsafe-inline'; img-src %webview_cspSource% https:; script-src %webview_cspSource% 'nonce-%nonce%'; script-src-elem %webview_cspSource% 'nonce-%nonce%'; connect-src %webview_cspSource% https:; frame-src https:;">
+<meta http-equiv="Content-Security-Policy" content="default-src %webview_cspSource%; style-src %webview_cspSource% 'unsafe-inline'; img-src %webview_cspSource% https: data:; script-src %webview_cspSource% 'nonce-%nonce%'; script-src-elem %webview_cspSource% 'nonce-%nonce%'; connect-src %webview_cspSource% https:; frame-src https:;">
 <meta name="version" content="9.0.3">
 <meta name="date" content="">
 <title>Netron</title>

--- a/webview/index.html
+++ b/webview/index.html
@@ -634,6 +634,24 @@ button { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI"
 			vscode.postMessage({command: 'alert',
 								text: message + "\n" + detail})
 		};
+		let exportRequestId = 0;
+		const exportRequests = new Map();
+
+		window.__view__._host.export = async function(file, blob) {
+			const id = ++exportRequestId;
+			const buffer = await blob.arrayBuffer();
+
+			return new Promise((resolve, reject) => {
+				exportRequests.set(id, { resolve, reject });
+				vscode.postMessage({
+					command: 'export',
+					id,
+					file,
+					type: blob.type,
+					data: Array.from(new Uint8Array(buffer))
+				});
+			});
+		};
 
 		// Ask to host to send model
 		vscode.postMessage({command: 'request_model'});
@@ -646,6 +664,18 @@ button { font-family: -apple-system, BlinkMacSystemFont, "Segoe WPC", "Segoe UI"
 					const file1 = new File([Uint8Array.from(message.value)], "%GRAPHNAME%", {type: ''});
 					window.__view__._host._open(file1, [file1]);
 					break;
+				case 'export_complete': {
+					const request = exportRequests.get(message.id);
+					if (request) {
+						exportRequests.delete(message.id);
+						if (message.error) {
+							request.reject(new Error(message.error));
+						} else {
+							request.resolve();
+						}
+					}
+					break;
+				}
 			}
 				
 		});


### PR DESCRIPTION
## Summary

Fixes #8.

This updates the VS Code webview export flow so Netron exports are saved through VS Code instead of relying on browser downloads, which are blocked or unreliable inside webviews.

- Override the webview host export handler to send generated export blobs back to the extension host.
- Handle export messages in the extension host with `showSaveDialog()` and `workspace.fs.writeFile()` so users can choose where to save SVG/PNG files.
- Allow `data:` image sources in the webview CSP because PNG export rasterizes a temporary SVG data URI before writing the PNG blob.

## Testing

- Ran `npm run compile`.
- Ran `npm run lint`.
- Manually verified `Export as SVG` opens a save dialog and writes the selected file.
- Manually verified `Export as PNG` opens a save dialog and writes the selected file.